### PR TITLE
Added Node/TypeScript import

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Parse the [Firestore REST API](https://firebase.google.com/docs/firestore/refere
 ## Examples
 [Live Example](https://repl.it/@jdbence/firestore-parser-example-01)
 ```JS
-  // const FireStoreParser = require('firestore-parser');
+	// Node/AMD: 
+	// const FireStoreParser = require('firestore-parser');
+	// Node with TypeScript:
+	// import * as FireStoreParser from 'firestore-parser';
   import FireStoreParser from 'firestore-parser'
   const projectID = 'PROJECT_ID'
   const key = 'API_KEY'

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Parse the [Firestore REST API](https://firebase.google.com/docs/firestore/refere
 ## Examples
 [Live Example](https://repl.it/@jdbence/firestore-parser-example-01)
 ```JS
-	// Node/AMD: 
-	// const FireStoreParser = require('firestore-parser');
-	// Node with TypeScript:
-	// import * as FireStoreParser from 'firestore-parser';
+  // Node/AMD: 
+  // const FireStoreParser = require('firestore-parser');
+  // Node with TypeScript:
+  // import * as FireStoreParser from 'firestore-parser';
   import FireStoreParser from 'firestore-parser'
   const projectID = 'PROJECT_ID'
   const key = 'API_KEY'


### PR DESCRIPTION
When importing on a Node with TypeScript project and using the instructions in the README.md, the FireStoreParser call failed at runtime. To solve the problem, I changed the import statement and thought I'd add it to the README.md.